### PR TITLE
Move try{} catch{} up one level.

### DIFF
--- a/RomanPort.PCParadiseBot/Modules/PartSaleModule/PartSaleModule.cs
+++ b/RomanPort.PCParadiseBot/Modules/PartSaleModule/PartSaleModule.cs
@@ -44,7 +44,11 @@ namespace RomanPort.PCParadiseBot.Modules.PartSaleModule
             {
                 while (true)
                 {
-                    await UpdateList();
+                    try {
+                        await UpdateList();
+                    } catch (Exception ex) {
+                        await LogToServer("Failed to Update", "Failed to update sales message! Message may have been deleted or failed network request.", null);
+                    }
                     await Task.Delay(UPDATE_INTERVAL);
                 }
             });
@@ -69,13 +73,7 @@ namespace RomanPort.PCParadiseBot.Modules.PartSaleModule
 
             //Build and update message
             DiscordEmbed embed = builder.Build();
-            try
-            {
-                await salesMessage.ModifyAsync(content:"", embed: embed);
-            } catch (Exception ex)
-            {
-                await LogToServer("Failed to Update", "Failed to update sales message! Was it deleted?", null);
-            }
+            await salesMessage.ModifyAsync(content:"", embed: embed);
         }
     }
 }


### PR DESCRIPTION
UpdateList(); can inherently fail in multiple places. Putting a try{} catch{} up one level handles all of these areas at once, and is preferable to handling all of the failure points (reddit.GetSub(), posts.MoveNextAsync(), salesMessage.ModifyAsync()) one at a time for code legibility, and because there's no real alternative to just re-running those pieces again anyways. Under this implementation it does wait until UPDATE_INTERVAL to try again however which is worth noting.